### PR TITLE
Problem: glard does not show a version number

### DIFF
--- a/src/glard.c
+++ b/src/glard.c
@@ -30,6 +30,8 @@
 int
 main (int argc, char *argv [])
 {
+    puts ("glard v0.1.2 -- GL-AR150 demo'n");
+
     //  Defaults
     bool verbose = false;
     bool console = false;


### PR DESCRIPTION
Solution: display this at startup
