### PR TITLE
add openwrt build script openwrt-build.sh and openwrt-build.md doc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:14.04
+MAINTAINER Benjamin Henrion <zoobab@gmail.com>
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y -q
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --force-yes build-essential subversion git-core libncurses5-dev zlib1g-dev gawk flex quilt libssl-dev xsltproc libxml-parser-perl mercurial bzr ecj cvs unzip wget
+
+RUN useradd -d /home/openwrt -m -s /bin/bash openwrt
+RUN echo "openwrt ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/openwrt
+RUN chmod 0440 /etc/sudoers.d/openwrt
+
+USER openwrt
+
+WORKDIR /home/openwrt
+RUN git clone --quiet https://github.com/mirrors/openwrt.git
+WORKDIR /home/openwrt/openwrt
+# checking out version 48724 (svn) == 4eba46dc3a80529146329a5f28629429d6fb3cd5 (git)
+RUN git checkout 4eba46dc3a80529146329a5f28629429d6fb3cd5
+RUN echo "CONFIG_TARGET_ar71xx=y" > .config
+RUN make defconfig
+RUN make prereq
+RUN make -j`nproc` tools/install
+RUN make -j`nproc` toolchain/install
+RUN echo "src-git zmq https://github.com/zoobab/openwrt-zmq-packages.git" >> feeds.conf.default
+RUN ./scripts/feeds update zmq
+RUN ./scripts/feeds install -p zmq
+RUN ./scripts/feeds update -a
+RUN ./scripts/feeds install -a
+RUN make -j`nproc`
+
+RUN echo "CONFIG_PACKAGE_glard=y" >> .config
+RUN make oldconfig
+RUN make -j`nproc`

--- a/openwrt-build.md
+++ b/openwrt-build.md
@@ -1,0 +1,58 @@
+How to build the openwrt image
+==============================
+
+Just run the `openwrt-build.sh` script as a user (not root), tested under
+ubuntu 14.04.
+
+First of all, you have to be root without password prompt preferably, here an
+example how to add the user `joe` for sudo, those steps have to be done with
+the root user:
+
+```
+$ export MYUSER="joe"
+$ echo "$MYUSER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$MYUSER
+$ chmod 0440 /etc/sudoers.d/$MYUSER
+```
+
+This has been tested under ubuntu 14.04, if you want other distributions, look
+at the OpenWRT requirements here:
+
+https://wiki.openwrt.org/doc/howto/buildroot.exigence
+
+Then, just run the `openwrt-build.sh` script as a user (not root):
+
+```
+./openwrt-build.sh
+```
+
+At the end of the process, you should end up with a firmware bin file named
+`openwrt-ar71xx-generic-gl-ar150-squashfs-sysupgrade.bin` which
+contains glard and all the zmq libs in the `openwrt/bin/ar71xx` directory:
+
+```
+zoobab@sabayonx86-64 /home/zoobab/soft/glar150/openwrt/bin/ar71xx [13]$ ls   
+md5sums                                                  openwrt-ar71xx-generic-uImage-lzma.bin   openwrt-ar71xx-generic-vmlinux.lzma
+openwrt-ar71xx-generic-gl-ar150-squashfs-sysupgrade.bin  openwrt-ar71xx-generic-vmlinux-lzma.elf  packages
+openwrt-ar71xx-generic-root.squashfs                     openwrt-ar71xx-generic-vmlinux.bin       sha256sums
+openwrt-ar71xx-generic-root.squashfs-64k                 openwrt-ar71xx-generic-vmlinux.elf
+openwrt-ar71xx-generic-uImage-gzip.bin                   openwrt-ar71xx-generic-vmlinux.gz
+```
+
+You should then upload this file in the default firmware of Gl.inet by going to
+the web interface of the device, -> Advanced Settings -> User+passwd -> System
+-> Backup/FlashFirmware -> Flash New Firmware Image -> Choose File -> Flash
+Image
+
+Do no power up the device, and wait 3 minutes at least.
+
+The device will reboot with a 192.168.1.1 IP address, you should be able to:
+
+a. ping if you put a static IP on your PC (like 192.168.1.2)
+b. a DHCP address from your PC
+
+From there, you should be able to reach the default web interface
+http://192.168.1.1 or telnet to the device.
+
+Sometimes the previous configuration is not erased, so it will keep its default
+IP address (192.168.8.1), so if you want to wipe it out, you should login in
+telnet or ssh, and run `firstboot` to erase the previous settings.

--- a/openwrt-build.sh
+++ b/openwrt-build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -x
+
+if [[ $(id -u) -eq 0 ]] ; then
+    echo "Please do not run as root!";
+    exit 1;
+fi
+
+DEBIAN_FRONTEND=noninteractive sudo apt-get update -y -q
+DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -q --force-yes build-essential subversion git-core libncurses5-dev zlib1g-dev gawk flex quilt libssl-dev xsltproc libxml-parser-perl mercurial bzr ecj cvs unzip wget
+
+git clone https://github.com/mirrors/openwrt.git
+cd openwrt/
+git checkout 4eba46dc3a80529146329a5f28629429d6fb3cd5
+
+echo "src-git zmq https://github.com/zoobab/openwrt-zmq-packages.git" >> feeds.conf.default
+uniq feeds.conf.default > feeds.conf.default
+./scripts/feeds update zmq
+./scripts/feeds install -p zmq
+./scripts/feeds update -a
+./scripts/feeds install -a
+
+# "=y" means in the firmware image, "=m" means as an external *.ipk package
+echo "CONFIG_TARGET_ar71xx_generic_GL-AR150=y" > .config
+echo "CONFIG_PACKAGE_glard=y" >> .config
+make defconfig
+make 


### PR DESCRIPTION
Add Dockerfile that builds openwrt for glar150 with glard

add a build.sh

remove RUN

do not run as root

mv build.sh -> openwrt-build.sh

make -j nproc

openwrt-build.sh: make sure feeds.conf.default has one line per entry

openwrt-build.sh: remove not needed make steps

openwrt-build.sh: add some comment

openwrt-build.md: add some human nodes

openwrt-build.md: fix syntax

openwrt-build.sh: run make instead of make -j4
